### PR TITLE
Revert "Bump jackson-databind from 2.11.3 to 2.12.7.1 (#45)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <jaxb.sun.version>2.3.4</jaxb.sun.version>
         <joda-time.version>2.10.8</joda-time.version>
         <jackson-joda.version>2.9.7</jackson-joda.version>
-        <jackson.version>2.12.7.1</jackson.version>
+        <jackson.version>2.11.3</jackson.version>
         <jersey.version>2.30</jersey.version>
         <guava.version>30.0-jre</guava.version>
         <lombok.version>1.18.20</lombok.version>


### PR DESCRIPTION
This reverts commit 3a161aaca8b7f53bc5c761371e1db1fecc613bfc.

The jackson.version property is also used by jackson-annotations, version 2.12.7.1 does not exist.