### PR TITLE
812: release actions fix merge master

### DIFF
--- a/.github/workflows/merge-master.yml
+++ b/.github/workflows/merge-master.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Release snapshot package to forgerock maven snapshot repository
         run: mvn -B deploy --file pom.xml
-        with:
+        env:
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
 


### PR DESCRIPTION
- Fix error in merge-master workflow change `with` to `env` to inject properly the environment maven settings

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/812