### PR TITLE
812: release prepare action

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -88,7 +88,7 @@ jobs:
       - name: push branch
         id: push_branch
         run: |
-          git push --set-upstream origin ${{ steps.create_release_context.outputs.release_branch }}
+          git push -f --set-upstream origin ${{ steps.create_release_context.outputs.release_branch }}
 
       # Release prepare
       # - Change the version in the POM from x-SNAPSHOT to the new version provided for the release_version_number input


### PR DESCRIPTION
When the branch contains the format is release/x.y.z-rc.1 (release candidate with sequence number)
```shell
# git command:
git push --set-upstream origin "release/0.9.0-rc.1"
# response from github: 
To github.com:SecureApiGateway/secure-api-gateway-parent.git
 ! [rejected]        release/0.9.0-rc.1 -> release/0.9.0-rc.1 (non-fast-forward)
error: failed to push some refs to 'github.com:SecureApiGateway/secure-api-gateway-parent.git'
hint: Updates were rejected because the tip of your current branch is behind
hint: its remote counterpart. Integrate the remote changes (e.g.
hint: 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
```
> Works when the branch name is `x.y.z-rc.1` with no path-branch or `path-branch/x.y.z-rc` with no sequence number at the end or any other semantic version.

> adding the flag `-f` to force the push fix the problem.

- Added force flag to push branch step

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/812