### PR TITLE
Issue/812 release action no maven

### DIFF
--- a/.github/workflows/release-prepare-no-maven.yml
+++ b/.github/workflows/release-prepare-no-maven.yml
@@ -1,0 +1,66 @@
+name: release-prepare
+run-name: Prepare Release '${{ inputs.release_version_number }}'
+on:
+  workflow_call:
+    inputs:
+      release_version_number:
+        required: true
+        type: string
+      java_version:
+        required: false
+        type: string
+        default: '14'
+    outputs:
+      release_branch_ref:
+        description: "Release branch"
+        value: ${{ jobs.release_prepare.outputs.release_branch_ref }}
+      release_tag_ref:
+        description: "Release tag"
+        value: ${{ jobs.release_prepare.outputs.release_tag_ref }}
+    secrets:
+      GIT_COMMIT_USERNAME_BOT:
+        required: true
+      GIT_COMMIT_AUTHOR_EMAIL_BOT:
+        required: true
+env:
+  # Set the environment with secrets provided by the caller (secrets section)
+  GIT_AUTHOR_NAME: ${{ secrets.GIT_COMMIT_USERNAME_BOT }}
+  GIT_AUTHOR_EMAIL: ${{ secrets.GIT_COMMIT_AUTHOR_EMAIL_BOT }}
+  GIT_COMMITTER_NAME: ${{ secrets.GIT_COMMIT_USERNAME_BOT }}
+  GIT_COMMITTER_EMAIL: ${{ secrets.GIT_COMMIT_AUTHOR_EMAIL_BOT }}
+
+jobs:
+  release_prepare:
+    name: Release prepare
+    runs-on: ubuntu-latest
+    # Map the job outputs to step outputs
+    outputs:
+      release_branch_ref: ${{ steps.create_release_context.outputs.release_branch }}
+      release_tag_ref: ${{ steps.create_release_context.outputs.release_tag }}
+
+    steps:
+      # https://github.com/actions/checkout
+      - uses: actions/checkout@v3
+        id: checkout_master
+        name: checkout master
+
+      # Create branch context variable
+      - name: Create release context
+        id: create_release_context
+        run: |
+          echo "release_branch=release/${{ inputs.release_version_number }}" >> $GITHUB_OUTPUT
+          echo "release_tag=v${{ inputs.release_version_number }}" >> $GITHUB_OUTPUT
+
+      # create the release branch with release version number provided
+      - name: create release branch
+        id: create_release_branch
+        run: |
+          echo "Release branch: ${{ steps.create_release_context.outputs.release_branch }}"
+          git checkout -b ${{ steps.create_release_context.outputs.release_branch }}
+
+      # push the branch to remote repository
+      - name: push branch
+        id: push_branch
+        run: |
+          git push -f --set-upstream origin ${{ steps.create_release_context.outputs.release_branch }}
+          

--- a/.github/workflows/release-prepare-no-maven.yml
+++ b/.github/workflows/release-prepare-no-maven.yml
@@ -1,15 +1,15 @@
-name: release-prepare
-run-name: Prepare Release '${{ inputs.release_version_number }}'
+name: release-prepare-no-maven
+run-name: Prepare Release (no maven) '${{ inputs.release_version_number }}'
+# Workflow to prepare the release for projects without maven
+# - Creates the release branch
+# - Creates the release tag
+# - Push release branch and tag
 on:
   workflow_call:
     inputs:
       release_version_number:
         required: true
         type: string
-      java_version:
-        required: false
-        type: string
-        default: '14'
     outputs:
       release_branch_ref:
         description: "Release branch"
@@ -31,7 +31,7 @@ env:
 
 jobs:
   release_prepare:
-    name: Release prepare
+    name: Release prepare no maven
     runs-on: ubuntu-latest
     # Map the job outputs to step outputs
     outputs:

--- a/.github/workflows/release-prepare-no-maven.yml
+++ b/.github/workflows/release-prepare-no-maven.yml
@@ -58,9 +58,17 @@ jobs:
           echo "Release branch: ${{ steps.create_release_context.outputs.release_branch }}"
           git checkout -b ${{ steps.create_release_context.outputs.release_branch }}
 
-      # push the branch to remote repository
-      - name: push branch
-        id: push_branch
+      # create the release branch with release version number provided
+      - name: create release tag
+        id: create_release_tag
+        run: |
+          echo "Release tag: ${{ steps.create_release_context.outputs.release_tag }}"
+          git tag -a ${{ steps.create_release_context.outputs.release_tag }} -m "Tag for release ${{ inputs.release_version_number }}"
+
+      # push the branch and tag to remote repository
+      - name: push branch and tag
+        id: push_branch_tag
         run: |
           git push -f --set-upstream origin ${{ steps.create_release_context.outputs.release_branch }}
+          git push -f origin ${{ steps.create_release_context.outputs.release_tag }}
           

--- a/.github/workflows/release-publish-draft-only.yml
+++ b/.github/workflows/release-publish-draft-only.yml
@@ -1,0 +1,42 @@
+name: release-publish-draft-only
+run-name: Release draft '${{ inputs.release_version_number }}'
+# Workflow to create a release draft from release tag
+on:
+  workflow_call:
+    inputs:
+      release_version_number:
+        required: true
+        type: string
+      release_tag_ref:
+        required: true
+        type: string
+      release_notes:
+        description: "Release notes"
+        required: false
+        type: string
+        default: ''
+
+env:
+  GH_TOKEN: ${{ github.token }} # needed to run gh cli commands
+
+jobs:
+
+  release_publish_draft:
+    name: Publish release draft
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/actions/checkout
+      - uses: actions/checkout@v3
+        id: checkout_release_branch
+        name: checkout release branch
+        with:
+          fetch-depth: 0
+
+      # Creates a release draft from tag
+      - name: Create github release draft
+        id: gh_release_draft
+        run: |
+          # Create a release from input tag
+          gh release create  --draft \
+          --verify-tag ${{ inputs.release_tag_ref }} \
+          --title "${{ inputs.release_version_number }}" --notes "${{ inputs.release_notes }}"


### PR DESCRIPTION
As we have projects to be released where maven is not used we need a different workflows for these projects.
- Created workflow to prepare the release for these projects where maven is not used
- Created workflow to publish a release draft only (the projects where maven is not used don't have commits to create a PR)

Issue: https://github.com/secureapigateway/secureapigateway/issues/812

> For v2.0.0 release strategy we can add a mandatory flags in the current workflows to skip no necessary steps, for example to skip create a PR when the project to be released doesn't needed, or skip the deploy goal step for these projects where maven is not used.
