### PR TITLE
1223: Remove guava dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,6 @@
         <jackson-joda.version>2.14.2</jackson-joda.version>
         <jackson.version>2.14.2</jackson.version>
         <jersey.version>2.30</jersey.version>
-        <guava.version>30.0-jre</guava.version>
         <lombok.version>1.18.20</lombok.version>
         <bouncycastle.version>1.67</bouncycastle.version>
         <model-mapper.version>2.4.4</model-mapper.version>
@@ -178,12 +177,6 @@
                 <groupId>net.logstash.logback</groupId>
                 <artifactId>logstash-logback-encoder</artifactId>
                 <version>${logstash.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${guava.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Dependabot has identified a security issue with the version of guava referenced in our parent pom, however we are not using guava in any of our projects.

Removing guava from the parent pom

https://github.com/SecureApiGateway/SecureApiGateway/issues/1223