### PR TITLE
1219: Updating to bouncy castle version 1.77

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <jersey.version>2.30</jersey.version>
         <guava.version>33.0.0-jre</guava.version>
         <lombok.version>1.18.20</lombok.version>
-        <bouncycastle.version>1.67</bouncycastle.version>
+        <bouncycastle.version>1.77</bouncycastle.version>
         <model-mapper.version>2.4.4</model-mapper.version>
         <nimbus-jose.version>9.1.3</nimbus-jose.version>
         <logstash.version>6.4</logstash.version>
@@ -252,7 +252,7 @@
 
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk15on</artifactId>
+                <artifactId>bcprov-jdk18on</artifactId>
                 <version>${bouncycastle.version}</version>
             </dependency>
 


### PR DESCRIPTION
Switching to jdk18on (JDK 1.8+) flavour of bouncy castle libraries and updating them to version 1.77

jdk15on (JDK 1.5+) flavour is no longer being developed.

This will resolve the dependabot PR: https://github.com/SecureApiGateway/secure-api-gateway-parent/pull/51 , it is unable to update to v1.77 as the artifact name is changing.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1219