### PR TITLE
1238: Removing unused dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,13 +87,11 @@
         <joda-time.version>2.10.8</joda-time.version>
         <jackson-joda.version>2.14.2</jackson-joda.version>
         <jackson.version>2.14.2</jackson.version>
-        <jersey.version>2.30</jersey.version>
         <guava.version>33.0.0-jre</guava.version>
         <lombok.version>1.18.20</lombok.version>
         <bouncycastle.version>1.77</bouncycastle.version>
         <model-mapper.version>2.4.4</model-mapper.version>
         <nimbus-jose.version>9.1.3</nimbus-jose.version>
-        <logstash.version>6.4</logstash.version>
         <httpclient.version>4.5.13</httpclient.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
 
@@ -101,10 +99,6 @@
         <assertj.version>3.18.1</assertj.version>
         <mockito.version>3.5.15</mockito.version>
         <flapdoodle-mongo.version>4.12.0</flapdoodle-mongo.version>
-        <wiremock.version>2.27.2</wiremock.version>
-        <inject.resources.version>0.3.2</inject.resources.version>
-        <!-- TODO - Can we get rid of this? -->
-        <jmockdata.version>4.2.0</jmockdata.version>
 
         <!-- Plugin versions -->
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
@@ -145,11 +139,6 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>${commons-lang3.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>net.logstash.logback</groupId>
-                <artifactId>logstash-logback-encoder</artifactId>
-                <version>${logstash.version}</version>
             </dependency>
 
             <dependency>
@@ -199,14 +188,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.glassfish.jersey</groupId>
-                <artifactId>jersey-bom</artifactId>
-                <version>${jersey.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
-            <dependency>
                 <groupId>javax.xml.bind</groupId>
                 <artifactId>jaxb-api</artifactId>
                 <version>${jaxb-api.version}</version>
@@ -241,24 +222,8 @@
             </dependency>
             <dependency>
                 <groupId>io.springfox</groupId>
-                <artifactId>springfox-swagger-ui</artifactId>
-                <version>${springfox.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.springfox</groupId>
                 <artifactId>springfox-boot-starter</artifactId>
                 <version>${springfox.version}</version>
-            </dependency>
-            <!-- https://github.com/hosuaby/inject-resources -->
-            <dependency>
-                <groupId>io.hosuaby</groupId>
-                <artifactId>inject-resources-core</artifactId>
-                <version>${inject.resources.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.hosuaby</groupId>
-                <artifactId>inject-resources-junit-jupiter</artifactId>
-                <version>${inject.resources.version}</version>
             </dependency>
             <!-- 3rd Party Test dependencies -->
 
@@ -286,13 +251,6 @@
                         <artifactId>junit-vintage-engine</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>com.github.jsonzou</groupId>
-                <artifactId>jmockdata</artifactId>
-                <scope>test</scope>
-                <version>${jmockdata.version}</version>
             </dependency>
 
             <dependency>
@@ -341,14 +299,6 @@
                 <groupId>de.flapdoodle.embed</groupId>
                 <artifactId>de.flapdoodle.embed.mongo.spring27x</artifactId>
                 <version>${flapdoodle-mongo.version}</version>
-                <scope>test</scope>
-            </dependency>
-
-            <!-- Wiremock -->
-            <dependency>
-                <groupId>com.github.tomakehurst</groupId>
-                <artifactId>wiremock</artifactId>
-                <version>${wiremock.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
Removing the following:
- logstash-logback-encoder
- org.glassfish.jersey
- springfox-swagger-ui
- inject-resources-core
- jmockdata
- wiremock

https://github.com/SecureApiGateway/SecureApiGateway/issues/1238