### PR TITLE
1244: Remove springfox dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <hibernate-validator.version>7.0.1.Final</hibernate-validator.version>
         <hibernate-validator-cdi.version>7.0.1.Final</hibernate-validator-cdi.version>
         <javax-el.version>3.0.1-b12</javax-el.version>
-        <springfox.version>3.0.0</springfox.version>
+        <swagger-annotations.version>1.6.12</swagger-annotations.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <jaxb.sun.version>2.3.4</jaxb.sun.version>
         <joda-time.version>2.10.8</joda-time.version>
@@ -216,15 +216,11 @@
             </dependency>
 
             <dependency>
-                <groupId>io.springfox</groupId>
-                <artifactId>springfox-swagger2</artifactId>
-                <version>${springfox.version}</version>
+                <groupId>io.swagger</groupId>
+                <artifactId>swagger-annotations</artifactId>
+                <version>${swagger-annotations.version}</version>
             </dependency>
-            <dependency>
-                <groupId>io.springfox</groupId>
-                <artifactId>springfox-boot-starter</artifactId>
-                <version>${springfox.version}</version>
-            </dependency>
+
             <!-- 3rd Party Test dependencies -->
 
             <!-- JUnit 5 -->


### PR DESCRIPTION
springfox is not being used, it is only required as it transitively pulls in the swagger-annotations dependency required by our code.

Removing springfox and adding swagger-annotations.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1244