### PR TITLE
1235: Upgrade Spring to 3.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,10 +76,10 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>17</java.version>
 
-        <spring-boot.version>2.7.18</spring-boot.version>
-        <validation-api.version>2.0.1.Final</validation-api.version>
-        <hibernate-validator.version>7.0.1.Final</hibernate-validator.version>
-        <hibernate-validator-cdi.version>7.0.1.Final</hibernate-validator-cdi.version>
+        <spring-boot.version>3.2.1</spring-boot.version>
+        <jakarta.validation-api.version>3.1.0-M1</jakarta.validation-api.version>
+        <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
+        <hibernate-validator-cdi.version>8.0.1.Final</hibernate-validator-cdi.version>
         <javax-el.version>3.0.1-b12</javax-el.version>
         <swagger-annotations.version>1.6.12</swagger-annotations.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
@@ -154,9 +154,9 @@
             </dependency>
 
             <dependency>
-                <groupId>javax.validation</groupId>
-                <artifactId>validation-api</artifactId>
-                <version>${validation-api.version}</version>
+                <groupId>jakarta.validation</groupId>
+                <artifactId>jakarta.validation-api</artifactId>
+                <version>${jakarta.validation-api.version}</version>
             </dependency>
 
             <!-- Jackson -->

--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,7 @@
             </dependency>
             <dependency>
                 <groupId>de.flapdoodle.embed</groupId>
-                <artifactId>de.flapdoodle.embed.mongo.spring27x</artifactId>
+                <artifactId>de.flapdoodle.embed.mongo.spring3x</artifactId>
                 <version>${flapdoodle-mongo.version}</version>
                 <scope>test</scope>
             </dependency>
@@ -311,6 +311,7 @@
                         <release>${java.version}</release>
                         <verbose>false</verbose>
                         <fork>true</fork>
+                        <parameters>true</parameters>
                     </configuration>
                 </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <bouncycastle.version>1.77</bouncycastle.version>
         <model-mapper.version>2.4.4</model-mapper.version>
         <nimbus-jose.version>9.1.3</nimbus-jose.version>
-        <httpclient.version>4.5.13</httpclient.version>
+        <httpclient.version>5.2.3</httpclient.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
 
         <junit-jupiter.version>5.7.0</junit-jupiter.version>
@@ -131,8 +131,8 @@
 
             <!-- Other 3rd Party -->
             <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpclient</artifactId>
+                <groupId>org.apache.httpcomponents.client5</groupId>
+                <artifactId>httpclient5</artifactId>
                 <version>${httpclient.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Major version update of Spring to 3.2.1

Changes:
- javax.validation changes to jakarta.validation
- update hibernate version (which implements jakarta.validation) to version 8.0.1
- httpclient version 5.2.3
- de.flapdoodle.embed.mongo.spring27x dependency replaced with de.flapdoodle.embed.mongo.spring3x
- Enable compiler parameter name retention
  - Required by the RS for certain reflection based mapping
  - https://github.com/spring-projects/spring-framework/wiki/Upgrading-to-Spring-Framework-6.x#parameter-name-retention