### PR TITLE
1260: Investigate PR runs for GitHub user

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -92,5 +92,5 @@ jobs:
         id: push
         run: |
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
-          git tag -a ${{ steps.create_release_context.outputs.release_tag }} -m "Tag for release ${{ inputs.release_version_number }}"
+          git push origin ${{ steps.create_release_context.outputs.release_tag }}
           git push -f

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -10,19 +10,17 @@ on:
         required: false
         type: string
         default: '17'
+      github_release_user:
+        required: true
+        type: string
+      github_release_email:
+        required: true
+        type: string
     outputs:
       release_tag_ref:
         description: "Release tag"
         value: ${{ jobs.release_prepare.outputs.release_tag_ref }}
     secrets:
-      GPG_PRIVATE_KEY_BOT:
-        required: true
-      GPG_KEY_PASSPHRASE_BOT:
-        required: true
-      GIT_COMMIT_USERNAME_BOT:
-        required: true
-      GIT_COMMIT_AUTHOR_EMAIL_BOT:
-        required: true
       release_github_token:
         required: true
 
@@ -37,7 +35,7 @@ jobs:
 
     steps:
       # https://github.com/actions/checkout
-      - name: Checkout Parent Repo
+      - name: Checkout Repo
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.release_github_token }}
@@ -56,23 +54,18 @@ jobs:
         id: create_release_context
         run: |
           echo "release_tag=v${{ inputs.release_version_number }}" >> $GITHUB_OUTPUT
-          git config --global user.name "fropenbanking"
-          git config --global user.email "obst@forgerock.com"
+          git config --global user.name ${{ inputs.github_release_user }}
+          git config --global user.email ${{ inputs.github_release_email }}
 
       # Release prepare
       # - Change the version in the POM from x-SNAPSHOT to the new version provided for the release_version_number input
       # - Transform the SCM information in the POM to include the final destination of the tag
-      # - Commit the modified POM
-      # - Tag the code in the SCM with a version name (v${{ inputs.release_version_number }})
-      # See in the pom file the configuration '<tagNameFormat>v@{project.version}</tagNameFormat>'
       # - Bump the version in the POM to a new value, the next development iteration (y-SNAPSHOT)
-      # - Commit the modified POM
-      - name: release prepare
+      - name: Releases
         run: |
           mvn -B release:clean release:prepare -DreleaseVersion=${{ inputs.release_version_number }} -DpushChanges=false
 
-      # pushing changes done by the release prepare step (development snapshot version)
-      - name: push development snapshot version
+      - name: Create Tag and Push Changes for Next Release
         run: |
           git push origin ${{ steps.create_release_context.outputs.release_tag }}
           git push -f

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -25,13 +25,13 @@ on:
         required: true
       release_github_token:
         required: true
-env:
-  # Set the environment with secrets provided by the caller (secrets section)
-  GIT_AUTHOR_NAME: ${{ secrets.GIT_COMMIT_USERNAME_BOT }}
-  GIT_AUTHOR_EMAIL: ${{ secrets.GIT_COMMIT_AUTHOR_EMAIL_BOT }}
-  GIT_COMMITTER_NAME: ${{ secrets.GIT_COMMIT_USERNAME_BOT }}
-  GIT_COMMITTER_EMAIL: ${{ secrets.GIT_COMMIT_AUTHOR_EMAIL_BOT }}
-  GITHUB_TOKEN: ${{ secrets.release_github_token }}
+# env:
+#   # Set the environment with secrets provided by the caller (secrets section)
+#   GIT_AUTHOR_NAME: ${{ secrets.GIT_COMMIT_USERNAME_BOT }}
+#   GIT_AUTHOR_EMAIL: ${{ secrets.GIT_COMMIT_AUTHOR_EMAIL_BOT }}
+#   GIT_COMMITTER_NAME: ${{ secrets.GIT_COMMIT_USERNAME_BOT }}
+#   GIT_COMMITTER_EMAIL: ${{ secrets.GIT_COMMIT_AUTHOR_EMAIL_BOT }}
+#   GITHUB_TOKEN: ${{ secrets.release_github_token }}
 
 jobs:
   release_prepare:
@@ -58,13 +58,13 @@ jobs:
       # https://github.com/crazy-max/ghaction-import-gpg
       # https://httgp.com/signing-commits-in-github-actions/
       # Prepare the environment to sign the commits
-      - name: Import GPG Key
-        uses: crazy-max/ghaction-import-gpg@v5
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY_BOT }}
-          passphrase: ${{ secrets.GPG_KEY_PASSPHRASE_BOT }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
+#      - name: Import GPG Key
+#        uses: crazy-max/ghaction-import-gpg@v5
+#        with:
+#          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY_BOT }}
+#          passphrase: ${{ secrets.GPG_KEY_PASSPHRASE_BOT }}
+#          git_user_signingkey: true
+#          git_commit_gpgsign: true
 
       # Create tag context variable
       - name: Create Release Context
@@ -89,4 +89,8 @@ jobs:
       - name: push development snapshot version
         id: push
         run: |
+          git config --global user.name "fropenbanking"
+          git config --global user.email "obst@forgerock.com"
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git tag -a ${{ steps.create_release_context.outputs.release_tag }} -m "Tag for release ${{ inputs.release_version_number }}"
           git push -f

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -94,3 +94,4 @@ jobs:
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           git push origin ${{ steps.create_release_context.outputs.release_tag }}
           git push -f
+          exit 1

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -25,13 +25,7 @@ on:
         required: true
       release_github_token:
         required: true
-#env:
-  ## Set the environment with secrets provided by the caller (secrets section)
-  #GIT_AUTHOR_NAME: ${{ secrets.GIT_COMMIT_USERNAME_BOT }}
-  #GIT_AUTHOR_EMAIL: ${{ secrets.GIT_COMMIT_AUTHOR_EMAIL_BOT }}
-  #GIT_COMMITTER_NAME: ${{ secrets.GIT_COMMIT_USERNAME_BOT }}
-  #GIT_COMMITTER_EMAIL: ${{ secrets.GIT_COMMIT_AUTHOR_EMAIL_BOT }}
-  #GITHUB_TOKEN: ${{ secrets.release_github_token }}
+
 
 jobs:
   release_prepare:
@@ -57,17 +51,6 @@ jobs:
           architecture: x64
           cache: 'maven'
 
-      # https://github.com/crazy-max/ghaction-import-gpg
-      # https://httgp.com/signing-commits-in-github-actions/
-      # Prepare the environment to sign the commits
-#      - name: Import GPG Key
-#        uses: crazy-max/ghaction-import-gpg@v5
-#        with:
-#          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY_BOT }}
-#          passphrase: ${{ secrets.GPG_KEY_PASSPHRASE_BOT }}
-#          git_user_signingkey: true
-#          git_commit_gpgsign: true
-
       # Create tag context variable
       - name: Create Release Context
         id: create_release_context
@@ -91,8 +74,5 @@ jobs:
       # pushing changes done by the release prepare step (development snapshot version)
       - name: push development snapshot version
         run: |
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
-          git config --list
           git push origin ${{ steps.create_release_context.outputs.release_tag }}
           git push -f
-          exit 1

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -83,7 +83,7 @@ jobs:
       - name: release prepare
         id: maven_release
         run: |
-          mvn -B release:clean release:prepare -DreleaseVersion=${{ inputs.release_version_number }}
+          mvn -B release:clean release:prepare -DreleaseVersion=${{ inputs.release_version_number }} -DpushChanges=false
 
       # pushing changes done by the release prepare step (development snapshot version)
       - name: push development snapshot version

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -26,12 +26,12 @@ on:
       release_github_token:
         required: true
 env:
-  # # Set the environment with secrets provided by the caller (secrets section)
-  # GIT_AUTHOR_NAME: ${{ secrets.GIT_COMMIT_USERNAME_BOT }}
-  # GIT_AUTHOR_EMAIL: ${{ secrets.GIT_COMMIT_AUTHOR_EMAIL_BOT }}
-  # GIT_COMMITTER_NAME: ${{ secrets.GIT_COMMIT_USERNAME_BOT }}
-  # GIT_COMMITTER_EMAIL: ${{ secrets.GIT_COMMIT_AUTHOR_EMAIL_BOT }}
-  GITHUB_TOKEN: ${{ secrets.release_github_token }}
+  ## Set the environment with secrets provided by the caller (secrets section)
+  #GIT_AUTHOR_NAME: ${{ secrets.GIT_COMMIT_USERNAME_BOT }}
+  #GIT_AUTHOR_EMAIL: ${{ secrets.GIT_COMMIT_AUTHOR_EMAIL_BOT }}
+  #GIT_COMMITTER_NAME: ${{ secrets.GIT_COMMIT_USERNAME_BOT }}
+  #GIT_COMMITTER_EMAIL: ${{ secrets.GIT_COMMIT_AUTHOR_EMAIL_BOT }}
+  #GITHUB_TOKEN: ${{ secrets.release_github_token }}
 
 jobs:
   release_prepare:
@@ -46,7 +46,7 @@ jobs:
       - name: Checkout Parent Repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.release_github_token }}
 
       # set java and cache
       - name: Set Java and Maven Cache

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -25,13 +25,13 @@ on:
         required: true
       release_github_token:
         required: true
-# env:
-#   # Set the environment with secrets provided by the caller (secrets section)
-#   GIT_AUTHOR_NAME: ${{ secrets.GIT_COMMIT_USERNAME_BOT }}
-#   GIT_AUTHOR_EMAIL: ${{ secrets.GIT_COMMIT_AUTHOR_EMAIL_BOT }}
-#   GIT_COMMITTER_NAME: ${{ secrets.GIT_COMMIT_USERNAME_BOT }}
-#   GIT_COMMITTER_EMAIL: ${{ secrets.GIT_COMMIT_AUTHOR_EMAIL_BOT }}
-#   GITHUB_TOKEN: ${{ secrets.release_github_token }}
+env:
+  # # Set the environment with secrets provided by the caller (secrets section)
+  # GIT_AUTHOR_NAME: ${{ secrets.GIT_COMMIT_USERNAME_BOT }}
+  # GIT_AUTHOR_EMAIL: ${{ secrets.GIT_COMMIT_AUTHOR_EMAIL_BOT }}
+  # GIT_COMMITTER_NAME: ${{ secrets.GIT_COMMIT_USERNAME_BOT }}
+  # GIT_COMMITTER_EMAIL: ${{ secrets.GIT_COMMIT_AUTHOR_EMAIL_BOT }}
+  GITHUB_TOKEN: ${{ secrets.release_github_token }}
 
 jobs:
   release_prepare:
@@ -85,13 +85,11 @@ jobs:
       # - Bump the version in the POM to a new value, the next development iteration (y-SNAPSHOT)
       # - Commit the modified POM
       - name: release prepare
-        id: maven_release
         run: |
           mvn -B release:clean release:prepare -DreleaseVersion=${{ inputs.release_version_number }} -DpushChanges=false
 
       # pushing changes done by the release prepare step (development snapshot version)
       - name: push development snapshot version
-        id: push
         run: |
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           git config --list

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -71,6 +71,8 @@ jobs:
         id: create_release_context
         run: |
           echo "release_tag=v${{ inputs.release_version_number }}" >> $GITHUB_OUTPUT
+          git config --global user.name "fropenbanking"
+          git config --global user.email "obst@forgerock.com"
 
       # Release prepare
       # - Change the version in the POM from x-SNAPSHOT to the new version provided for the release_version_number input
@@ -89,8 +91,6 @@ jobs:
       - name: push development snapshot version
         id: push
         run: |
-          git config --global user.name "fropenbanking"
-          git config --global user.email "obst@forgerock.com"
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           git tag -a ${{ steps.create_release_context.outputs.release_tag }} -m "Tag for release ${{ inputs.release_version_number }}"
           git push -f

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -25,7 +25,7 @@ on:
         required: true
       release_github_token:
         required: true
-env:
+#env:
   ## Set the environment with secrets provided by the caller (secrets section)
   #GIT_AUTHOR_NAME: ${{ secrets.GIT_COMMIT_USERNAME_BOT }}
   #GIT_AUTHOR_EMAIL: ${{ secrets.GIT_COMMIT_AUTHOR_EMAIL_BOT }}

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -45,6 +45,8 @@ jobs:
       # https://github.com/actions/checkout
       - name: Checkout Parent Repo
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       # set java and cache
       - name: Set Java and Maven Cache

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -92,6 +92,7 @@ jobs:
         id: push
         run: |
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git config --list
           git push origin ${{ steps.create_release_context.outputs.release_tag }}
           git push -f
           exit 1


### PR DESCRIPTION
- Remove need to use GPG keys in workflow as can set the git config via cli
- Add in inputs for cli user and email
- Use PAT token during checkout of code so that protected branch can be overwritten
- no longer push changes during mvn command as unable to perform the required actions
- Push tag and changes in a separate step

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1260 