### PR TITLE
1389: Use CI Repo for standardised steps in github workflows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,25 +1,10 @@
-name: pull-request
-
-on: [pull_request]
-
+name: PR - Build and Deploy
+on:
+  pull_request:
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    name: Check PR integrity
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-java@v4
-        name: set java and maven cache
-        with:
-          distribution: 'zulu'
-          java-version: '17'
-          architecture: x64
-          cache: 'maven'
-
-      - name: Build and Test
-        run: mvn -B clean package --file pom.xml
-
-      - uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_ACCESS_TOKEN }}
+  run_pr-template:
+    name: PR - Build and Deploy
+    uses: SecureApiGateway/secure-api-gateway-ci/.github/workflows/reusable-pr.yml@1389-standard-steps-for-workflows
+    secrets: inherit
+    with:
+      componentName: secure-api-gateway-parent


### PR DESCRIPTION
Amend PR workflow to use steps in CI Repo
Creating PR for initial run through before amending other workflows

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1389