### PR TITLE
Update parent pom license checks current year to 2025

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+    Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@
     <properties>
         <!-- will be the last year in the copyright license header year range -->
         <!-- Will be changed every year -->
-        <copyright-current-year>2024</copyright-current-year>
+        <copyright-current-year>2025</copyright-current-year>
         <legal.path.header>legal/LICENSE-HEADER.txt</legal.path.header>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
Manually update the parent pom property representing the current year, so that downstream project license checks succeed (during `mvn license:check` part of build).

Ideally, this should be picked up automatically from the current date/timestamp.

TODO(later): Maybe see - auto-set property based on timestamp:
https://stackoverflow.com/questions/39307133/maven-property-for-current-year